### PR TITLE
feat: SKIP_WORKFLOW_DURATION_ESTIMATION

### DIFF
--- a/workflow/controller/estimation/estimator_factory.go
+++ b/workflow/controller/estimation/estimator_factory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/controller/indexes"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
@@ -29,12 +30,21 @@ type estimatorFactory struct {
 
 var _ EstimatorFactory = &estimatorFactory{}
 
+var (
+	skipWorkflowDurationEstimation = env.LookupEnvStringOr("SKIP_WORKFLOW_DURATION_ESTIMATION", "false")
+)
+
 func NewEstimatorFactory(wfInformer cache.SharedIndexInformer, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive) EstimatorFactory {
 	return &estimatorFactory{wfInformer, hydrator, wfArchive}
 }
 
 func (f *estimatorFactory) NewEstimator(wf *wfv1.Workflow) (Estimator, error) {
 	defaultEstimator := &estimator{wf: wf}
+
+	if skipWorkflowDurationEstimation == "true" {
+		return defaultEstimator, nil
+	}
+
 	for labelName, indexName := range map[string]string{
 		common.LabelKeyWorkflowTemplate:        indexes.WorkflowTemplateIndex,
 		common.LabelKeyClusterWorkflowTemplate: indexes.ClusterWorkflowTemplateIndex,


### PR DESCRIPTION
see https://github.com/argoproj/argo-workflows/issues/7271

And the many slow queries of form
```sql
Query: SELECT name,
       namespace,
       uid,
       phase,
       startedat,
       finishedat,
       Coalesce(workflow ->> '$.metadata.labels', '{}')      AS labels,
       Coalesce(workflow ->> '$.metadata.annotations', '{}') AS annotations,
       Coalesce(workflow ->> '$.status.progress', '')        AS progress
FROM   `argo_archived_workflows`
WHERE  ( ( `clustername` = ?
           AND `instanceid` = ? )
         AND `namespace` = ?
         AND EXISTS (SELECT 1
                     FROM   argo_archived_workflows_labels
                     WHERE  clustername = argo_archived_workflows.clustername
                            AND uid = argo_archived_workflows.uid
                            AND name = 'workflows.argoproj.io/phase'
                            AND value = 'Succeeded')
         AND EXISTS (SELECT 1
                     FROM   argo_archived_workflows_labels
                     WHERE  clustername = argo_archived_workflows.clustername
                            AND uid = argo_archived_workflows.uid
                            AND name = 'workflows.argoproj.io/workflow-template'
                            AND value = 'helloflow') )
ORDER  BY `startedat` DESC
LIMIT  1 
```