### PR TITLE
feat: Add SKIP_WORKFLOW_DURATION_ESTIMATION env var and update CI image tagging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,51 @@
+image: golang:1.21
+
+.install_docker:
+  before_script:
+    - |
+      wget -O docker-cli.deb https://download.docker.com/linux/debian/dists/bullseye/pool/stable/amd64/docker-ce-cli_20.10.18~3-0~debian-bullseye_amd64.deb && \
+      dpkg -i docker-cli.deb && \
+      rm docker-cli.deb
+
+variables:
+  MAJOR_VERSION: "0"
+  MINOR_VERSION: "1"
+  ORGANIZATION_NAME: "artificial-intelligence"
+  TEAM_NAME: "ai-platform"
+  ARGO_WORKFLOWS_VERSION: "v3.5.6"
+
+.build_templatized_docker_image:
+  before_script:
+    - !reference [.install_docker, before_script]
+    # Inject org & team names to conform to AIP naming conventions that make it possible to set
+    # permissions and retention policies at each level.
+    - IMAGE_REPOSITORY_PREFIX="${DOCKER_REPO_URL}/${ORGANIZATION_NAME}/${TEAM_NAME}"
+    # Ensure image tag uses branch/tag slug instead of pipeline ID
+    - IMAGE_TAG="${ARGO_WORKFLOWS_VERSION}-${CI_COMMIT_REF_SLUG}" # Use branch/tag slug
+    # Actually set up the naming for the image we're currently building.
+    - IMAGE_REPOSITORY="${IMAGE_REPOSITORY_PREFIX}/${ARTIFACT_NAME}"
+    - IMAGE_REPOSITORY_TAG="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+  script:
+    # Add echo for clarity
+    - echo "Running make dist/workflow-controller..."
+    - make dist/workflow-controller
+    # Add echo for clarity
+    - echo "Building Docker image... CONTEXT is -->${CONTEXT}<--"
+    - |
+      DOCKER_BUILDKIT=1 docker build \
+        --target workflow-controller \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        --build-arg "IMAGE_REPOSITORY_TAG=${IMAGE_REPOSITORY_TAG}" \
+        -t ${IMAGE_REPOSITORY_TAG} \
+        ${CONTEXT}
+    - echo ${DOCKER_API_KEY} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REPO_URL}
+    - docker push ${IMAGE_REPOSITORY_TAG}
+stages:
+  - build:images
+
+build:workflows:
+  extends: .build_templatized_docker_image
+  variables:
+    ARTIFACT_NAME: "argo-workflows"
+    CONTEXT: "./"
+  stage: build:images

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -54,6 +54,7 @@ most users. Environment variables may be removed at any time.
 | `WORKFLOW_GC_PERIOD`                     | `time.Duration`     | `5m`                                                                                        | The periodicity for GC of workflows.                                                                                                                                                                                                                                     |
 | `SEMAPHORE_NOTIFY_DELAY`                 | `time.Duration`     | `1s`                                                                                        | Tuning Delay when notifying semaphore waiters about availability in the semaphore                                                                                                                                                                                        |
 | `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS` | `bool` | `true` | Whether to watch the Controller's ConfigMap and semaphore ConfigMaps for run-time changes. When disabled, the Controller will only read these ConfigMaps once and will have to be manually restarted to pick up new changes. |
+| `SKIP_WORKFLOW_DURATION_ESTIMATION`     | `bool` | `false`| Whether to lookup resource usage from prior workflows to estimate usage for new workflows. |
 
 CLI parameters of the `argo-server` and `workflow-controller` can be specified as environment variables with the `ARGO_`
 prefix. For example:

--- a/workflow/controller/estimation/estimator_factory.go
+++ b/workflow/controller/estimation/estimator_factory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v3/persist/sqldb"
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"github.com/argoproj/argo-workflows/v3/util/env"
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/argoproj/argo-workflows/v3/workflow/controller/indexes"
 	"github.com/argoproj/argo-workflows/v3/workflow/hydrator"
@@ -29,12 +30,19 @@ type estimatorFactory struct {
 
 var _ EstimatorFactory = &estimatorFactory{}
 
+var (
+	skipWorkflowDurationEstimation = env.LookupEnvStringOr("SKIP_WORKFLOW_DURATION_ESTIMATION", "false")
+)
+
 func NewEstimatorFactory(wfInformer cache.SharedIndexInformer, hydrator hydrator.Interface, wfArchive sqldb.WorkflowArchive) EstimatorFactory {
 	return &estimatorFactory{wfInformer, hydrator, wfArchive}
 }
 
 func (f *estimatorFactory) NewEstimator(wf *wfv1.Workflow) (Estimator, error) {
 	defaultEstimator := &estimator{wf: wf}
+	if skipWorkflowDurationEstimation == "true" {
+		return defaultEstimator, nil
+	}
 	for labelName, indexName := range map[string]string{
 		common.LabelKeyWorkflowTemplate:        indexes.WorkflowTemplateIndex,
 		common.LabelKeyClusterWorkflowTemplate: indexes.ClusterWorkflowTemplateIndex,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #13745

### Motivation

The Argo workflow controllers on non-prod environments are getting stuck, and workflows are mostly not running. The current workflow duration estimation feature causes significant load on our RDS cluster, leading to these performance issues and operational instability. This feature provides an escape hatch to disable the resource usage lookup from prior workflows when estimating usage for new workflows.

### Modifications

- Added `SKIP_WORKFLOW_DURATION_ESTIMATION` environment variable to controller configuration
- When set to `true`, disables the workflow duration estimation feature that queries historical workflow data
- Updated environment variables documentation to include the new variable
- This is a cherry-pick of the upstream feature to improve operational stability without requiring a full version upgrade

### Verification

- Manually verified with custom DockerHub image: `docker.io/abdula/argo-workflows-controller:v3.5.6-with-skip-estimation-amd64`
- Tested in non-prod environments where controllers were previously getting stuck
- Confirmed that setting `SKIP_WORKFLOW_DURATION_ESTIMATION=true` resolves the performance issues
- Validated that workflows run normally without the duration estimation overhead

### Documentation

Updated `docs/environment-variables.md` to include the new `SKIP_WORKFLOW_DURATION_ESTIMATION` environment variable with proper description and default value. The feature is documented as a performance optimization for environments experiencing issues with workflow duration estimation.

Usage example:
```yaml
env:
  - name: SKIP_WORKFLOW_DURATION_ESTIMATION
    value: "true"
```

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->