### PR TITLE
fix: Adding fix for incorrect archived workflows URL redirecti…

### DIFF
--- a/ui/src/app/shared/base.ts
+++ b/ui/src/app/shared/base.ts
@@ -1,21 +1,29 @@
 function baseUrl(): string {
     const base = document.querySelector('base');
-    return base ? base.getAttribute('href') : '/';
+    return base ? base.getAttribute('href') || '/' : '/';
+}
+
+// joinBasePath joins the <base href> value with a UI/API path while collapsing
+// any duplicate slashes at the join point. This protects callers that pass
+// paths with or without a leading slash from producing URLs like
+// "/argo-ui//archived-workflows/..." when BASE_HREF is "/argo-ui/".
+function joinBasePath(base: string, path: string): string {
+    const normalizedBase = (base || '/').replace(/\/+$/, '');
+    const normalizedPath = (path || '').replace(/^\/+/, '');
+    return normalizedPath ? `${normalizedBase}/${normalizedPath}` : `${normalizedBase}/`;
 }
 
 export function uiUrl(uiPath: string): string {
-    return baseUrl() + uiPath;
+    return joinBasePath(baseUrl(), uiPath);
 }
 
 export function uiUrlWithParams(uiPath: string, params: string[]): string {
-    if (!params) {
-        return uiUrl(uiPath);
-    }
-    return baseUrl() + uiPath + '?' + params.join('&');
+    const url = joinBasePath(baseUrl(), uiPath);
+    return params && params.length > 0 ? `${url}?${params.join('&')}` : url;
 }
 
 export function apiUrl(apiPath: string): string {
-    return `${baseUrl()}${apiPath}`;
+    return joinBasePath(baseUrl(), apiPath);
 }
 
 export function absoluteUrl(path: string): string {


### PR DESCRIPTION
Fixes #AIP-10019

## Motivation

With `BASE_HREF=/argo-ui/`, the UI built URLs like
`/argo-ui//archived-workflows/<ns>/<uid>` because `uiUrl` / `apiUrl` naively concatenated the base href with paths that started with `/`. Archived-workflow links from `train-and-evaluate` (job [101830841](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/integration-tests/aip-workflow-example/-/jobs/101830841)) redirected to that broken URL.

The earlier fix attempt didn't ship: our `.gitlab-ci.yml` only built `--target workflow-controller`, but the UI is only compiled and embedded into the `argocli` image (used by the `argo-server` Deployment).

## Modifications

- `ui/src/app/shared/base.ts`: added `joinBasePath` (strips trailing `/` on base, leading `/` on path, joins with a single `/`) and routed `uiUrl`, `uiUrlWithParams`, `apiUrl` through it. Hardened `baseUrl()` to fall back to `/` when `<base href>` is missing.
- `ui/src/app/shared/base.test.ts` (new): regression tests covering all combinations of trailing/leading slashes, empty paths, and the original `/argo-ui//archived-workflows` case.
- `.gitlab-ci.yml`: parameterized `--target` via `DOCKER_TARGET`, dropped the redundant host-side `make dist/workflow-controller`, and added `build:argo-server` (target `argocli`, contains the UI) and `build:argoexec` jobs. Existing `build:workflow-controller` job keeps the `argo-workflows` artifact name for backwards compatibility.

## Verification

- Pipeline produces three image tags: `argo-workflows`, `argo-server`, `argoexec` (all `v3.5.6-<slug>`).
- Paired with [aip-k8s-manifests !666](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/aip-k8s-manifests/-/merge_requests/666), which bumps the `argo-server` Deployment to the new `argo-server` tag
- Re-run of `train-and-evaluate` in sandbox surfaces `/argo-ui/archived-workflows/<ns>/<uid>` (no `//`) and resolves correctly.